### PR TITLE
Remove excessive fields from the contract PATCH response

### DIFF
--- a/openprocurement/contracting/ceasefire/models/roles.py
+++ b/openprocurement/contracting/ceasefire/models/roles.py
@@ -33,8 +33,28 @@ CONTRACT_ROLES = {
         whitelist('contractType', 'buyers') +
         blacklist('milestones'),
     'view':
-        contract_view_role +
-        whitelist('contractType', 'milestones'),
+        whitelist(
+            'awardID',
+            'buyers',
+            'changes',
+            'contractID',
+            'contractNumber',
+            'contractType',
+            'dateSigned',
+            'description',
+            'documents',
+            'id',
+            'items',
+            'merchandisingobject',
+            'milestones',
+            'milestones',
+            'period',
+            'procuringEntity',
+            'status',
+            'title',
+            'type',
+            'value',
+        ),
     'edit_active.confirmation':
         contract_edit_role +
         blacklist('buyers', 'milestones'),

--- a/openprocurement/contracting/ceasefire/tests/constants.py
+++ b/openprocurement/contracting/ceasefire/tests/constants.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+CONTRACT_FIELDS_TO_HIDE = (
+    '_id',
+    '_rev',
+    'auction_token',
+    'doc_type',
+    'ovner_token',
+    'revisions',
+)

--- a/openprocurement/contracting/ceasefire/views/contract.py
+++ b/openprocurement/contracting/ceasefire/views/contract.py
@@ -48,4 +48,4 @@ class CeasefireContractResource(APIResource):
                     {'MESSAGE_ID': 'ceasefire_contract_patch'}
                     )
                 )
-            return {'data': self.request.context.serialize()}
+            return {'data': self.request.context.serialize('view')}


### PR DESCRIPTION
- Define `view` role explicitly.
- Add test for the hidden fields.