### PR TITLE
Update status change logic

### DIFF
--- a/openprocurement/contracting/ceasefire/adapters/milestone_manager.py
+++ b/openprocurement/contracting/ceasefire/adapters/milestone_manager.py
@@ -43,7 +43,7 @@ class CeasefireMilestoneManager(object):
         # `notMet` handling
         if new_status == 'notMet' and milestone.status == 'processing':
             milestone.status = new_status
-            milestone.__parent__.status = 'unsuccessful'
+            milestone.__parent__.status = 'pending.unsuccessful'
 
         # handle patching `dueDate` of reporting milestone in `scheduled` status
         patched_dueDate = request.json.get('data', {}).get('dueDate')

--- a/openprocurement/contracting/ceasefire/tests/managers_test.py
+++ b/openprocurement/contracting/ceasefire/tests/managers_test.py
@@ -186,7 +186,7 @@ class CeasefireMilestoneManagerTest(unittest.TestCase):
         manager.change_milestone(mocked_request)
 
         self.assertEqual(mocked_milestone.status, 'notMet')
-        self.assertEqual(mocked_contract.status, 'unsuccessful')
+        self.assertEqual(mocked_contract.status, 'pending.unsuccessful')
 
     def test_choose_status_to_met(self):
         manager = CeasefireMilestoneManager(Mock())

--- a/openprocurement/contracting/ceasefire/tests/milestone_test.py
+++ b/openprocurement/contracting/ceasefire/tests/milestone_test.py
@@ -225,7 +225,7 @@ class MilestoneResourceTest(BaseWebTest):
 
         self.assertEqual(response.status, '200 OK')
         related_contract = get_contract(self, contract.data.id)
-        self.assertEqual(related_contract.status, 'unsuccessful')
+        self.assertEqual(related_contract.status, 'pending.unsuccessful')
 
     def test_patch_status(self):
         contract, milestones = prepare_milestones_approval(self)


### PR DESCRIPTION
When some milestone becames `notMet`, contract will became
`pending.unsuccessful`. Before this commit it would become
`unsuccessful`.